### PR TITLE
Update start_periodic_task to 30s period

### DIFF
--- a/app/src/main/java/com/google/example/gcmnetworkmanagerquickstart/MainActivity.java
+++ b/app/src/main/java/com/google/example/gcmnetworkmanagerquickstart/MainActivity.java
@@ -142,7 +142,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         PeriodicTask task = new PeriodicTask.Builder()
                 .setService(MyTaskService.class)
                 .setTag(TASK_TAG_PERIODIC)
-                .setPeriod(5L)
+                .setPeriod(30L)
                 .build();
 
         mGcmNetworkManager.schedule(task);


### PR DESCRIPTION
Periods under 30 seconds are not supported ([ref](https://developers.google.com/android/reference/com/google/android/gms/gcm/PeriodicTask)).
